### PR TITLE
Remove stock browser

### DIFF
--- a/pkg/META-INF/com/google/android/updater-script
+++ b/pkg/META-INF/com/google/android/updater-script
@@ -49,6 +49,10 @@ ui_print("| 80%  Disable CM Setup Wizard  |");
 set_progress(0.8);
 delete("/system/priv-app/CMAccount.apk");
 
+ui_print("| 85%  Removing stock browser   |");
+set_progress(0.85);
+delete("/system/app/Browser.apk");
+
 ui_print("| 90%  Unmounting filesystems   |");
 set_progress(0.9);
 run_program("/sbin/busybox", "umount", "/system");

--- a/scripts/download_apks.sh
+++ b/scripts/download_apks.sh
@@ -13,12 +13,12 @@ apk_files=( \
   com.fsck.k9_22002.apk \
   org.sufficientlysecure.keychain_31200.apk \
   net.osmand.plus_197.apk \
-  com.csipsimple_2417.apk \
+  com.csipsimple_2459.apk \
   com.projectsexception.myapplist.open_16.apk \
   fr.kwiatkowski.ApkTrack_1.apk \
   org.coolreader_875.apk \
   com.artifex.mupdfdemo_55.apk \
-  org.mozilla.fennec_fdroid_350010.apk \
+  org.mozilla.fennec_fdroid_360010.apk \
   fennec-35.0.multi.android-arm.apk \
   de.schildbach.wallet_209.apk \
   org.mariotaku.twidere_98.apk \


### PR DESCRIPTION
No longer needed as we're using fennec fdroid as the safe browser for captive portals