### PR TITLE
Get orwall to write rules on first boot

### DIFF
--- a/pkg/data/.firstboot.sh
+++ b/pkg/data/.firstboot.sh
@@ -90,8 +90,9 @@ done
 # This is a hack, and race conditions might occur if the .firstboot.sh script gets to long.
 am startservice org.torproject.android/org.torproject.android.service.TorService
 
-# Force open orWall to force writing of iptables rules. Close with HOME key.
-am start org.ethack.orwall/org.ethack.orwall.TabbedMain && input keyevent 3
+# Fake BOOT_COMPLETE to force orwall to apply rules in background.
+# TODO: Investigate why this doesn't happen on its own.
+am broadcast -a android.intent.action.BOOT_COMPLETED -n org.ethack.orwall/.BootBroadcast
 
 # Start time settings app so the user can set the clock.
 # FIXME: This could be done better with our own wizard, or maybe even if we

--- a/pkg/data/.firstboot.sh
+++ b/pkg/data/.firstboot.sh
@@ -90,6 +90,9 @@ done
 # This is a hack, and race conditions might occur if the .firstboot.sh script gets to long.
 am startservice org.torproject.android/org.torproject.android.service.TorService
 
+# Force open orWall to force writing of iptables rules. Close with HOME key.
+am start org.ethack.orwall/org.ethack.orwall.TabbedMain && input keyevent 3
+
 # Start time settings app so the user can set the clock.
 # FIXME: This could be done better with our own wizard, or maybe even if we
 # call into only specific activities of the CM one.

--- a/pkg/data/data/org.ethack.orwall/shared_prefs/org.ethack.orwall_preferences.xml
+++ b/pkg/data/data/org.ethack.orwall/shared_prefs/org.ethack.orwall_preferences.xml
@@ -1,6 +1,7 @@
 <?xml version='1.0' encoding='utf-8' standalone='yes' ?>
 <map>
     <string name="sip_app">REPLACE_WITH_SIP_UID</string>
+    <boolean name="first_run" value="false" />
     <string name="browser_app">REPLACE_WITH_BROWSER_UID</string>
     <boolean name="enforce_init_script" value="true" />
 </map>


### PR DESCRIPTION
Related to https://github.com/EthACKdotOrg/orWall/issues/72

These are the xml config diffs before and after we do a on-off toggle to fix. I'll test out which preset would get orwall to realize it's all configured and ready to set up its rules on the first boot

```diff
/non_encrypted/repos/mission-impossible-android (orwall-default-app-setup ✘)✹✭ ᐅ diff -u tmp/orwall-pref-pre.xml tmp/orwall-pref-post.xml 
--- tmp/orwall-pref-pre.xml	2015-02-26 16:31:07.836758719 -0500
+++ tmp/orwall-pref-post.xml	2015-02-26 16:39:31.188777902 -0500
@@ -1,6 +1,11 @@
 <?xml version='1.0' encoding='utf-8' standalone='yes' ?>
 <map>
+    <boolean name="enforce_init_script" value="true" />
+    <boolean name="ipt_comments" value="true" />
+    <boolean name="deactivate_init_script" value="false" />
     <string name="sip_app">10057</string>
+    <boolean name="first_run" value="false" />
+    <boolean name="orwall_enabled" value="true" />
     <string name="browser_app">10071</string>
-    <boolean name="enforce_init_script" value="true" />
+    <boolean name="browser_enabled" value="false" />
 </map>
```