### PR TITLE
Improve device name detection

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -11,8 +11,10 @@ function connect_adb()
 function get_device_name()
 {
   connect_adb
+  # The 'ro.product.device' property isn't very reliable.
   # Note: Whitespace character \r was causing odd formatting.
-  local device_name=`adb shell getprop ro.product.device | tr -d "\r"`
+  local device_name=`adb shell getprop ro.cm.device | tr -d "\r"`
+  [[ -z "$device_name" ]] && device_name=`adb shell getprop ro.product.device | tr -d "\r"`
   [[ -z "$device_name" ]] && device_name='DEVICE_CODENAME'
   echo "$device_name"
 }


### PR DESCRIPTION
The `ro.product.device` property isn't the most reliable, it has wrong values for 2 (Samsung Galaxy S2 & OnePlus One) out of 4 devices I tested with.

I tried finding a way to detect the device name on all of the 4 devices, but it can't really be done with out some more info from the CM guys on how they get them... The output of `adb devices -l` isn't good enough and neither are the properties inside `/system/build.prop`.

The only way to reliably get the device name to generate the CyanogenMod download link is to get the `ro.cm.device` property if the device already has CM installed.