### PR TITLE
Pre-install Flock app (contact/calendar management)

### DIFF
--- a/mia/templates/mia-default/settings.yaml
+++ b/mia/templates/mia-default/settings.yaml
@@ -52,6 +52,8 @@ apps:
     path: system-apps
   - name: info.guardianproject.orfox
     url: https://guardianproject.info/builds/OrfoxFennec/2014-08-22_23-32-22/OrfoxFennec-debug.apk
+  - name: org.anhonesteffort.flock
+    url: https://flock-supplychain.s3.amazonaws.com/apks/org.anhonesteffort.flock-4b93f078-cae6-4997-a1c2-ef833b2ac2c1.apk
   - name: com.artifex.mupdfdemo
     code: 55
   - name: com.csipsimple


### PR DESCRIPTION
WhisperSystem is using the Flock app to test non-Play store distribution, so we can snag it.